### PR TITLE
fix(nhk2025b_msgs): missing some depend

### DIFF
--- a/src/message/nhk2025b_msgs/package.xml
+++ b/src/message/nhk2025b_msgs/package.xml
@@ -12,6 +12,9 @@
   <depend>geometry_msgs</depend>
   <depend>builtin_interfaces</depend>
 
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
- rosidl_default_generatorsを追加
- rosidl_default_runtimeを追加
close #27 