### PR TITLE
fix(README): add class name before timer callback func

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ ament_auto_package(
 
 ### include/パッケージ名/ノード名.hpp
 ```cpp
-#ifndef __ノード名_HPP__
-#define __ノード名_HPP__
+#ifndef __ノード名_hpp__
+#define __ノード名_hpp__
 
 #include <rclcpp/rclcpp.hpp>
 // #include <test_msgs/msg/my_message.hpp>
@@ -132,7 +132,7 @@ namespace ネームスペース名 {
     };
 }
 
-#endif//__ノード名_HPP__
+#endif//__ノード名_hpp__
 ```
 
 ### src/ノード名.cpp
@@ -143,15 +143,17 @@ namespace ネームスペース名 {
     クラス名::クラス名(const rclcpp::NodeOptions & options)
         : Node("ノード名",options) {
             // パブリッシャー = this->create_publisher<test_msgs::msg::MyMessage>("topic名", 10);
-            // サブスクライバー = this->create_subscription<test_msgs::msg::MyMessage>("topic名", 10, std::bind(&クラス名::受信時に呼び出す関数名, this, std::placeholders::_1));
-            // タイマー = this->create_wall_timer(std::chrono::milliseconds(周期), std::bind(&クラス名::タイマーで呼び出す関数名, this));
+            // サブスクライバー = this->create_subscription<test_msgs::msg::MyMessage>
+            //    ("topic名", 10, std::bind(&クラス名::受信時に呼び出す関数名, this, std::placeholders::_1));
+            // タイマー = this->create_wall_timer(std::chrono::milliseconds(周期), 
+            //    std::bind(&クラス名::タイマーで呼び出す関数名, this));
         }
 
         // void クラス名::受信時に呼び出す関数名(const test_msgs::msg::MyMessage::SharedPtr msg) {
         //     msg->test のように->を使って情報にアクセス
         // }
 
-        // void タイマーで呼び出す関数名() {
+        // void クラス名::タイマーで呼び出す関数名() {
         //     定期的に実行
         // }
 }


### PR DESCRIPTION
- README.mdのサンプルのCPP修正
- タイマーで呼び出す関数の前にクラス名をつける必要がある