### PR TITLE
Fix version filter for `USE_SCOPED_HEADER_INSTALL_DIR` option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
     EXECUTABLE ノード名
 )
 
-if($ENV{ROS_DISTRO} STREQUAL "iron" OR $ENV{ROS_DISTRO} STREQUAL "jazzy" OR $ENV{ROS_DISTRO} STREQUAL "rolling")
+if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "jazzy")
   ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
 else()
   ament_auto_package(INSTALL_TO_SHARE)


### PR DESCRIPTION
Hi, I'm a contributor of `ament_cmake` that adds `USE_SCOPED_HEADER_INSTALL_DIR` option to `ament_auto_package` function.
Sorry for your confusion, but `USE_SCOPED_HEADER_INSTALL_DIR` option is present only in `humble` and `jazzy`.
For distributions above quilt, including rolling, there are no options, and the default behavior is the same as when the option is enabled.

Note: The reason why Iron does not include the option is because Iron was already EOL when the option was implemented